### PR TITLE
bugfix/566

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -4910,6 +4910,32 @@
                 </ol>
               </nav>
             </div>
+            <h4 class="docs__sub_style">Buttons</h4>
+            <p>Each link, <code>class="fsa-breadcrumb__link"</code>, may occasionally be a <code>button</code> element.</p>
+            <div class="fsa-breadcrumb">
+              <nav class="fsa-breadcrumb__nav" aria-label="Breadcrumbs">
+                <ol class="fsa-breadcrumb__list">
+                  <li class="fsa-breadcrumb__item">
+                    <button class="fsa-breadcrumb__link" type="button">Level 0</button>
+                  </li>
+                  <li class="fsa-breadcrumb__item">
+                    <button class="fsa-breadcrumb__link" type="button">
+                      <span class="">Level 1</span>
+                    </button>
+                  </li>
+                  <li class="fsa-breadcrumb__item">
+                    <button class="fsa-breadcrumb__link" type="button">
+                      <span class="">Level 2</span>
+                    </button>
+                  </li>
+                  <li class="fsa-breadcrumb__item">
+                    <button class="fsa-breadcrumb__link" type="button">
+                      <span class="">Level 3</span>
+                    </button>
+                  </li>
+                </ol>
+              </nav>
+            </div>
             <h4 class="docs__sub_style">With icons</h4>
             <div class="fsa-breadcrumb">
               <nav class="fsa-breadcrumb__nav" aria-label="Breadcrumbs">

--- a/src/stylesheets/components/_fsa.breadcrumb.scss
+++ b/src/stylesheets/components/_fsa.breadcrumb.scss
@@ -61,6 +61,7 @@
   &__link {
 
     & {
+      @include reset-button();
       color: $color-fsa-link;
       text-decoration: none;
       display: inline-flex;


### PR DESCRIPTION
added @include reset-button() to .fsa-breadcrumb__link, added new breadcrumb as button example to kitchen sink